### PR TITLE
Upgrade to latest lts 13.22

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,3 @@
-resolver: lts-10.0
+resolver: lts-13.22
 packages:
 - .


### PR DESCRIPTION
Addresses GH-13

You may need to do `stack upgrade` before `stack build`,
otherwise you are likely to get errors such as:

```
Unable to load cabal files for snapshot
...
Unable to parse cabal file for foo
```